### PR TITLE
fix passing startUrl to request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,30 @@ The extension is written in TypeScript. Between changes, you can simply run the 
 ./bin/test.sh
 ```
 
+# Building the extension
+First make sure you have the VSTS extension CLI:
+
+```
+$ npm install -g tfx-cli
+```
+
+You will need to increment the appropriate version number before you can build and publish this extension:
+
+ * [vss-extension.json](./vss-extension.json)
+ * [run-suite-task/package.json](run-suite-task/package.json)
+ * [run-suite-task/task.json](run-suite-task/task.json)
+
+
+Create the extension with this command:
+```
+$ tfx extension create
+```
+
+The extension should now be in the project root under `ghost-inspector.ghost-inspector-vsts-extension-<version>.vsix`.
+
 ## Issues
 Please report any issues [on Github](https://github.com/ghost-inspector/ghost-inspector-vsts-extension/issues) or [through our support channel](https://ghostinspector.com/support/).
 
 ## Change Log
- - 2018-Feb-26 - 1.0.0: Initial release
+ - 2018-02-26 - 1.0.0: Initial release
+ - 2018-03-13 - 1.0.1: Patch to fix not passing startUrl

--- a/run-suite-task/ghost-inspector/services/index.ts
+++ b/run-suite-task/ghost-inspector/services/index.ts
@@ -22,6 +22,9 @@ export class Suite {
   get body (): object {
     let params = this.request.params
     params.immediate = 1
+    if (this.request.startUrl) {
+      params.startUrl = this.request.startUrl
+    }
     return params
   }
 

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Trigger your Ghost Inspector test suite in your VSTS build.",
   "main": "index.js",
   "repository": {

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -9,7 +9,7 @@
   "version": {
       "Major": 1,
       "Minor": 0,
-      "Patch": 0
+      "Patch": 1
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [

--- a/run-suite-task/tests/services.ts
+++ b/run-suite-task/tests/services.ts
@@ -26,6 +26,7 @@ describe('services.Suite', function () {
     assert.equal(service.body.browser, 'chrome', 'browser')
     assert.equal(service.body.myVar, 'hello', 'myVar')
     assert.equal(service.body.immediate, 1, 'immediate')
+    assert.equal(service.body.startUrl, 'https://somewhere.com', 'startUrl')
   })
 
   it('should execute the request', async function () {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your VSTS build.",
   "tags": [
     "Automated Testing",


### PR DESCRIPTION
This change modifies the extension so it actually passes `startUrl` to the API on suite execution.

Also some docs around publishing.