### PR TITLE
Params fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ node_js:
   - 8.9.4
 
 script:
-  - npm config set strict-ssl false
+  - npm install -g typescript
   - cd run-suite-task && npm install . && cd ..
   - bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 0.8
+  - 8.9.4
 
 script:
   - npm config set strict-ssl false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - 0.8
 
 script:
+  - cd run-suite-task && npm install . && cd ..
   - bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+node_js:
+  - 0.8
+
+script:
+  - bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - 0.8
 
 script:
+  - npm config set strict-ssl false
   - cd run-suite-task && npm install . && cd ..
   - bin/test.sh

--- a/overview.md
+++ b/overview.md
@@ -1,5 +1,4 @@
 # Getting started with Ghost Inspector
-**Build status**: ![build status](https://circleci.com/gh/ghost-inspector/ghost-inspector-vsts-extension.svg?circle-token=05c5ca3ba409f6a6766a455a2aae6811b822003e)
 
 Ghost Inspector is an automated website testing and monitoring service that checks for problems with your website or application. It carries out operations in a browser, the same way a user would, to ensure that everything is working properly.
 

--- a/overview.md
+++ b/overview.md
@@ -1,4 +1,5 @@
 # Getting started with Ghost Inspector
+**Build status**: ![build status](https://travis-ci.org/ghost-inspector/ghost-inspector-vsts-extension.svg?branch=master)
 
 Ghost Inspector is an automated website testing and monitoring service that checks for problems with your website or application. It carries out operations in a browser, the same way a user would, to ensure that everything is working properly.
 

--- a/run-suite-task/ghost-inspector/services/index.ts
+++ b/run-suite-task/ghost-inspector/services/index.ts
@@ -29,9 +29,10 @@ export class Suite {
   }
 
   async poll (suiteResultId:string): Promise<boolean> {
-    const resultsUrl = `${this.suiteResultsBaseUrl}/${suiteResultId}/?apiKey=${this.request.apiKey}`
+    const safeUrl = `${this.suiteResultsBaseUrl}/${suiteResultId}/?apiKey=`
+    const resultsUrl = `${safeUrl}${this.request.apiKey}`
     await this.sleep(5000)
-    console.log('Polling for suite results', resultsUrl)
+    console.log('Polling for suite results', `${safeUrl}***`)
     const results:any = await axios.get(resultsUrl)
     const status:boolean = results.data.data.passing
 

--- a/run-suite-task/index.ts
+++ b/run-suite-task/index.ts
@@ -7,7 +7,7 @@ async function main() {
       task.getInput('apikey', true),
       task.getInput('suiteid', true),
       task.getInput('starturl', false),
-      task.getInput('params', false)
+      task.getInput('parameters', false)
     ))
 
     if (result) {

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Trigger your Ghost Inspector test suite in your VSTS build.",
   "main": "index.js",
   "repository": {

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -24,7 +24,7 @@
     "request": "^2.83.0",
     "typescript": "^2.7.1",
     "typings": "^2.1.1",
-    "vsts-task-lib": "^2.4.0"
+    "vsts-task-lib": "2.4.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^4.0.36",
     "@types/q": "^1.0.7",
     "@types/sinon": "^4.1.3",
-    "mocha": "^5.0.0",
+    "mocha": "^4.0.0",
     "sinon": "^4.3.0",
     "ts-mocha": "^1.1.0"
   }

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Trigger your Ghost Inspector test suite in your VSTS build.",
   "main": "index.js",
   "repository": {

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -20,11 +20,11 @@
   "author": "Ghost Inspector team",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.17.1",
+    "axios": "0.18.0",
     "request": "^2.83.0",
     "typescript": "^2.7.1",
     "typings": "^2.1.1",
-    "vsts-task-lib": "2.4.0"
+    "vsts-task-lib": "^2.4.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -24,7 +24,7 @@
     "request": "^2.83.0",
     "typescript": "^2.7.1",
     "typings": "^2.1.1",
-    "vsts-task-lib": "^2.2.1"
+    "vsts-task-lib": "^2.4"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -24,7 +24,7 @@
     "request": "^2.83.0",
     "typescript": "^2.7.1",
     "typings": "^2.1.1",
-    "vsts-task-lib": "^2.4"
+    "vsts-task-lib": "^2.4.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Trigger your Ghost Inspector test suite in your VSTS build.",
   "main": "index.js",
   "repository": {

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -9,7 +9,7 @@
   "version": {
       "Major": 1,
       "Minor": 0,
-      "Patch": 3
+      "Patch": 4
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -9,7 +9,7 @@
   "version": {
       "Major": 1,
       "Minor": 0,
-      "Patch": 2
+      "Patch": 3
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -9,7 +9,7 @@
   "version": {
       "Major": 1,
       "Minor": 0,
-      "Patch": 3
+      "Patch": 2
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your VSTS build.",
   "tags": [
     "Automated Testing",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your VSTS build.",
   "tags": [
     "Automated Testing",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your VSTS build.",
   "tags": [
     "Automated Testing",


### PR DESCRIPTION
Addresses an issue where parameters were not being passed properly into the extension (misnamed in the config). Also removes printing the API key out to the logs.

Reported here: https://github.com/ghost-inspector/ghost-inspector-vsts-extension/issues/5