### PR TITLE
Renames VSTS extension [ch2668]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Ghost Inspector Extension for Visual Studio Team Services
+Ghost Inspector Extension for Azure DevOps
 -------------
 
 Build status: ![build status](https://circleci.com/gh/ghost-inspector/ghost-inspector-vsts-extension.svg?style=shield&circle-token=05c5ca3ba409f6a6766a455a2aae6811b822003e)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ghost Inspector Extension for Azure DevOps
 -------------
 
-Build status: ![build status](https://circleci.com/gh/ghost-inspector/ghost-inspector-vsts-extension.svg?style=shield&circle-token=05c5ca3ba409f6a6766a455a2aae6811b822003e)
+Build status: ![build status](https://circleci.com/gh/ghost-inspector/ghost-inspector-azure-devops.svg?style=shield&circle-token=05c5ca3ba409f6a6766a455a2aae6811b822003e)
 
 With this plugin you can add a build step to your Azure DevOps project that executes a Ghost Inspector test suite. If the test suite is successful, your pipeline will continue to the next step in your pipeline; however, if it fails (or times out), the build will be marked as failed.
 
@@ -51,7 +51,7 @@ $ tfx extension create
 The extension should now be in the project root under `ghost-inspector.ghost-inspector-vsts-extension-<version>.vsix`.
 
 ## Issues
-Please report any issues [on Github](https://github.com/ghost-inspector/ghost-inspector-vsts-extension/issues) or [through our support channel](https://ghostinspector.com/support/).
+Please report any issues [on Github](https://github.com/ghost-inspector/ghost-inspector-azure-devops/issues) or [through our support channel](https://ghostinspector.com/support/).
 
 ## Change Log
  - 2020-01-27 - `1.0.8`: Updates references in docs from "VSTS" to "Azure DevOps"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The extension should now be in the project root under `ghost-inspector.ghost-ins
 Please report any issues [on Github](https://github.com/ghost-inspector/ghost-inspector-vsts-extension/issues) or [through our support channel](https://ghostinspector.com/support/).
 
 ## Change Log
+ - 2020-01-27 - `1.0.8`: Updates references in docs from "VSTS" to "Azure DevOps"
  - 2019-09-19 - `1.0.7`: Obscure exposed API key in suite execute call, update dependencies
  - 2019-05-01 - `1.0.6`: Updates `axios` to address vulnerability
  - 2018-07-18 - `1.0.5`: Add compatibility for TFS2017 (node `v5.x`/`ES5`)

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Ghost Inspector Extension for Visual Studio Team Services
 
 Build status: ![build status](https://circleci.com/gh/ghost-inspector/ghost-inspector-vsts-extension.svg?style=shield&circle-token=05c5ca3ba409f6a6766a455a2aae6811b822003e)
 
-With this plugin you can add a build step to your VSTS project that executes a Ghost Inspector test suite. If the test suite is successful, your pipeline will continue to the next step in your pipeline; however, if it fails (or times out), the build will be marked as failed.
+With this plugin you can add a build step to your Azure DevOps project that executes a Ghost Inspector test suite. If the test suite is successful, your pipeline will continue to the next step in your pipeline; however, if it fails (or times out), the build will be marked as failed.
 
 ## Installation
 This plugin can be installed from within the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ghost-inspector.ghost-inspector-vsts-extension).
 
 ## Prerequisites
 * **API Key** - This is a unique, private key provided with your account which allows you to access the API. You can find it in your Ghost Inspector account settings at https://app.ghostinspector.com/account.
-* **Suite ID** - The ID of the Ghost Inpsector suite that you would like to execute.
+* **Suite ID** - The ID of the Ghost Inspector suite that you would like to execute.
  
 ## Usage
 1. Install the extension from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ghost-inspector.ghost-inspector-vsts-extension).
-1. Open your project within VSTS and navigate to **Builds**. 
+1. Open your project within Azure DevOps and navigate to **Builds**.
 2. In the **Tasks** section, click the ```+``` icon to add a new task.
 3. To find the extension in the list quickly, type `Ghost` in the search box and select **Add**.
 4. Click on the new task and fill in the required fields for **Suite ID** and **API Key**.
@@ -30,7 +30,7 @@ The extension is written in TypeScript. Between changes, you can simply run the 
 ```
 
 # Building the extension
-First make sure you have the VSTS extension CLI:
+First make sure you have the Azure DevOps extension CLI:
 
 ```
 $ npm install -g tfx-cli

--- a/overview.md
+++ b/overview.md
@@ -1,6 +1,6 @@
 # Getting started with Ghost Inspector
 
-**Build status**: ![build status](https://travis-ci.org/ghost-inspector/ghost-inspector-vsts-extension.svg?branch=master)
+**Build status**: ![build status](https://api.travis-ci.org/ghost-inspector/ghost-inspector-azure-devops.svg?branch=master)
 
 Ghost Inspector is an automated website testing and monitoring service that checks for problems with your website or application. It carries out operations in a browser, the same way a user would, to ensure that everything is working properly.
 

--- a/overview.md
+++ b/overview.md
@@ -18,12 +18,12 @@ Some of our [key features](https://ghostinspector.com/learn-more/):
  * [Customize and override test settings](https://ghostinspector.com/docs/test-settings/) in advance or at runtime.
  * [Notify your team](https://ghostinspector.com/docs/notification/) when things haven't gone as expected.
 
-# Trigger tests from your VSTS build
-Adding Ghost Inspector test suite execution to your VSTS build is as simple as adding a new Ghost Inspector task.
+# Trigger tests from your Azure DevOps build
+Adding Ghost Inspector test suite execution to your Azure DevOps build is as simple as adding a new Ghost Inspector task.
 Once the task has been added, you have the ability to customize your build step:
 
  * **Suite ID**: specify the ID of the Ghost Inspector test suite you wish to execute.
  * **API Key**: provide your Ghost Inspector API key ([provided in your account](https://app.ghostinspector.com/account)).
  * **Start URL** (optional): provide the [alternative URL of your test environment](https://ghostinspector.com/docs/reusing-tests-different-environments/) to execute your test against.
- * **Additional Parameters** (optional): additionally provide [any other API paramaters](https://ghostinspector.com/docs/api/tests/#execute) or [custom variables](https://ghostinspector.com/docs/variables/) in JSON format (eg, `{"browser": "chrome", "myVar": "some value"}`).
+ * **Additional Parameters** (optional): additionally provide [any other API parameters](https://ghostinspector.com/docs/api/tests/#execute) or [custom variables](https://ghostinspector.com/docs/variables/) in JSON format (eg, `{"browser": "chrome", "myVar": "some value"}`).
  

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.7",
-  "description": "Trigger your Ghost Inspector test suite in your VSTS build.",
+  "version": "1.0.8",
+  "description": "Trigger your Ghost Inspector test suite in your Azure DevOps build.",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ghost-inspector/ghost-inspector-vsts-extension"
+    "url": "https://github.com/ghost-inspector/ghost-inspector-azure-devops"
   },
   "scripts": {
     "test": "./node_modules/ts-mocha/bin/ts-mocha tests/**/*.ts"

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -2,8 +2,8 @@
   "id": "C51CA1CE-0B54-627E-9571-3CBB14A64584",
   "name": "ghost-inspector-vsts-extension",
   "friendlyName": "Ghost Inspector",
-  "description": "Execute your Ghost Inspector test suites in your VSTS build.",
-  "helpMarkDown": "Execute your Ghost Inspector test suites in your VSTS build.",
+  "description": "Execute your Ghost Inspector test suites in your Azure DevOps build.",
+  "helpMarkDown": "Execute your Ghost Inspector test suites in your Azure DevOps build.",
   "category": "Test",
   "author": "Ghost Inspector",
   "version": {

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -9,7 +9,7 @@
   "version": {
       "Major": 1,
       "Minor": 0,
-      "Patch": 7
+      "Patch": 8
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -4,7 +4,7 @@
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
   "version": "1.0.7",
-  "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your VSTS build.",
+  "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your Azure DevOps build.",
   "tags": [
     "Automated Testing",
     "Integration Testing",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your Azure DevOps build.",
   "tags": [
     "Automated Testing",
@@ -52,10 +52,10 @@
         "uri": "https://ghostinspector.com/docs/getting-started/"
     },
     "repository": {
-      "uri": "https://github.com/ghost-inspector/ghost-inspector-vsts-extension"
+      "uri": "https://github.com/ghost-inspector/ghost-inspector-azure-devops"
     },
     "issues": {
-      "uri": "https://github.com/ghost-inspector/ghost-inspector-vsts-extension/issues"
+      "uri": "https://github.com/ghost-inspector/ghost-inspector-azure-devops/issues"
     },
     "support": {
       "uri": "mailto:help@ghostinspector.com"
@@ -63,7 +63,7 @@
   },
   "repository": {
     "type": "git",
-    "uri": "https://github.com/ghost-inspector/ghost-inspector-vsts-extension"
+    "uri": "https://github.com/ghost-inspector/ghost-inspector-azure-devops"
   },
   "files": [
     {


### PR DESCRIPTION
https://app.clubhouse.io/ghostinspector/story/2668/rename-vsts-extension

This updates references to VSTS in the documentation, but I did not update [other references](https://github.com/ghost-inspector/ghost-inspector-vsts-extension/search?q=vsts&unscoped_q=vsts) to ~~the URL of this repo (yet) or~~ the `name`/`id` in package.json, task.json, and vss-extension.json. I assume those are connected to the Visual Studio marketplace and I'm not sure if they need to change really.