### PR TITLE
Add support for multiple suite result responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Please report any issues [on Github](https://github.com/ghost-inspector/ghost-in
 
 ## Change Log
 
+- 2020-11-18 - `1.0.14`: Add support for data sources responses.
 - 2020-10-27 - `1.0.13`: Improve logging around failed execution responses.
 - 2020-04-21 - `1.0.12`: Adds `vso.release_execute` scope.
 - 2020-04-06 - `1.0.11`: Rebundles package, `1.0.10` was missing `*.js` files and would not execute.

--- a/run-suite-task/package-lock.json
+++ b/run-suite-task/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Trigger your Ghost Inspector test suite in your Azure DevOps build.",
   "main": "index.js",
   "repository": {

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your Azure DevOps build.",
   "tags": [
     "Automated Testing",


### PR DESCRIPTION
This addresses #20, the API response for suite execution was adjusted recently to accommodate execution with data sources which result in the `response.body.data` being list instead of an object. 

This change internally treats every response as a list and passes when all the polled results are passing, otherwise fails.